### PR TITLE
Sync w/ 18F/samhsa-prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-test-renderer": "^16.10.2"
   },
   "reactSnap": {
+    "skipThirdPartyRequests": true,
     "puppeteerArgs": [
       "--no-sandbox",
       "--disable-setuid-sandbox"

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#ffffff" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>%REACT_APP_SITE_TITLE%</title>
-    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_API_KEY%&libraries=places"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=quarterly&key=%REACT_APP_GOOGLE_API_KEY%&libraries=places"></script>
     <script
       type="text/javascript"
       src="//script.crazyegg.com/pages/scripts/0083/6179.js"

--- a/src/components/Input/Location.js
+++ b/src/components/Input/Location.js
@@ -128,6 +128,7 @@ class Location extends Component {
           onSelect={this.handleSelect}
           onError={this.handleError}
           ref={el => (this._placesAutocomplete = el)}
+          googleCallbackName="googleMapsLoaded"
         >
           {({ getInputProps, suggestions, getSuggestionItemProps }) => (
             <>


### PR DESCRIPTION
Bringing over https://github.com/18F/samhsa-prototype/pull/1


> Pinning our google maps javascript API version to quarterly(3.38)
> 
> Also tackling CBHSQ#557 here by:
> 
> Preventing 3rd party requests while pre-rendering the site. This means DAP, google analytics, and google maps are not loaded during pre-rendering.
> Setting a value for googleCallbackName on the PlacesAutoComplete component. The presence of a value allows the App to load without google maps being present.
> Preview branch: https://cg-efcd7c90-b365-4336-8b87-6174f1975c99.app.cloud.gov/preview/18f/samhsa-prototype/pin-gmaps/